### PR TITLE
Allow overriding CheckSigningTable config option by command line options

### DIFF
--- a/opendkim/opendkim.8.in
+++ b/opendkim/opendkim.8.in
@@ -7,6 +7,7 @@
 [\-A]
 [\-b modes]
 [\-c canon]
+[\-C|\-g]
 [\-d domain[,...]]
 [\-D]
 [\-e name]
@@ -262,6 +263,14 @@ The value may include two different canonicalizations separated by a
 slash ("/") character, in which case the first will be applied to the
 headers and the second to the body.
 .TP
+.I \-C
+Do check of the SigningTable for any missing keys in the KeyTable on
+loading config file.  This overrides config option CheckSigningTable in
+.I opendkim.conf(5).
+In conjunction with
+.I \-n
+option described below, you can perform the check only.
+.TP
 .I \-d dataset
 A set of domains whose mail should be signed by this filter.  Mail from
 other domains will be verified rather than being signed.
@@ -283,8 +292,9 @@ forks and exits immediately, leaving the service running in the background.
 This flag suppresses that behaviour so that it runs in the foreground.
 .TP
 .I \-g
-Skip checking the SigningTable for any missing keys in the KeyTable.  This 
-is the same as setting CheckSigningTable=no in opendkim.conf(5).
+Skip check of the SigningTable for any missing keys in the KeyTable.
+This overrides the config option CheckSigningTable in
+-I opendkim.conf(5).
 .TP
 .I \-F time
 Specifies a fixed time to use when generating signatures.  Ignored unless

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -137,7 +137,7 @@
 #endif /* _FFR_REPUTATION */
 
 /* macros */
-#define CMDLINEOPTS	"Ab:c:d:De:fF:gk:lL:no:p:P:Qrs:S:t:T:u:vVWx:X?"
+#define CMDLINEOPTS	"Ab:c:Cd:De:fF:gk:lL:no:p:P:Qrs:S:t:T:u:vVWx:X?"
 
 #ifndef MIN
 # define MIN(x,y)	((x) < (y) ? (x) : (y))
@@ -15474,6 +15474,7 @@ usage(void)
 	                "\t-A          \tauto-restart\n"
 	                "\t-b modes    \tselect operating modes\n"
 	                "\t-c canon    \tcanonicalization to use when signing\n"
+	                "\t-C          \tdo walk SigningTable when loading config\n"
 	                "\t-d domlist  \tdomains to sign\n"
 	                "\t-D          \talso sign subdomains\n"
 	                "\t-e name     \textract configuration value and exit\n"
@@ -15607,6 +15608,12 @@ main(int argc, char **argv)
 			if (optarg == NULL || *optarg == '\0')
 				return usage();
 			curconf->conf_canonstr = optarg;
+			break;
+
+		  case 'C':
+			use_cf_checksigningtable = FALSE;
+			init_checksigningtable = TRUE;
+			curconf->conf_checksigningtable = TRUE;
 			break;
 
 		  case 'd':

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -248,7 +248,7 @@ struct dkimf_config
 	_Bool		conf_noheaderb;		/* suppress "header.b" */
 	_Bool		conf_singleauthres;	/* single Auth-Results */
 	_Bool		conf_safekeys;		/* check key permissions */
-	_Bool		conf_checksigningtable; /* skip checking keys on startup */
+	_Bool		conf_checksigningtable; /* skip checking keys on dkimf_config_load */
 #ifdef _FFR_RESIGN
 	_Bool		conf_resignall;		/* resign unverified mail */
 #endif /* _FFR_RESIGN */
@@ -750,6 +750,8 @@ _Bool reload;					/* reload requested */
 _Bool no_i_whine;				/* noted ${i} is undefined */
 _Bool testmode;					/* test mode */
 _Bool allowdeprecated;				/* allow deprecated config values */
+_Bool init_checksigningtable;	/* initializing value for CheckSigningTable */
+_Bool use_cf_checksigningtable;	/* use CheckSigningTable on config file? */
 #ifdef QUERY_CACHE
 _Bool querycache;				/* local query cache */
 #endif /* QUERY_CACHE */
@@ -5883,7 +5885,7 @@ dkimf_config_new(void)
 	new->conf_atpshash = dkimf_atpshash[0].str;
 #endif /* _FFR_ATPS */
 	new->conf_selectcanonhdr = SELECTCANONHDR;
-	new->conf_checksigningtable = TRUE;
+	new->conf_checksigningtable = init_checksigningtable;
 
 	memcpy(&new->conf_handling, &defaults, sizeof new->conf_handling);
 
@@ -6201,10 +6203,12 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 		                  sizeof conf->conf_softstart);
 #endif /* (USE_LDAP || USE_ODBX) */
 
-		(void) config_get(data, "CheckSigningTable",
-		                  &conf->conf_checksigningtable,
-		                  sizeof conf->conf_checksigningtable);
-
+		if (use_cf_checksigningtable)
+		{
+			(void) config_get(data, "CheckSigningTable",
+			                  &conf->conf_checksigningtable,
+			                  sizeof conf->conf_checksigningtable);
+		}
 		(void) config_get(data, "DNSConnect",
 		                  &conf->conf_dnsconnect,
 		                  sizeof conf->conf_dnsconnect);
@@ -15564,6 +15568,8 @@ main(int argc, char **argv)
 #endif /* POPAUTH */
 	no_i_whine = TRUE;
 	conffile = NULL;
+	init_checksigningtable = TRUE;
+	use_cf_checksigningtable = TRUE;
 
 	memset(myhostname, '\0', sizeof myhostname);
 	(void) gethostname(myhostname, sizeof myhostname);
@@ -15652,6 +15658,8 @@ main(int argc, char **argv)
 			break;
 
 		  case 'g':
+			use_cf_checksigningtable = FALSE;
+			init_checksigningtable = FALSE;
 			curconf->conf_checksigningtable = FALSE;
 			break;
 


### PR DESCRIPTION
This is proposal for changing upstream PR https://github.com/trusteddomainproject/OpenDKIM/pull/228.

While I'm working on implementing a command line options  "`-C`" supposing to use with "`-n`" and just opposite of  "`-g`",  I became aware that command line option "`-g`" cannot override CheckSigningTable config option in config file.

With those commits,  we can override it by using command line option "`-C`" or "`-g`".

Note: without those commit,  opendkim milter ignores `"-g"` option on reloading config file (ordered by SIGHUP signal).